### PR TITLE
Replace https://www.w3.org/ns/credentials/examples/v2 with inline con…

### DIFF
--- a/contexts.json
+++ b/contexts.json
@@ -3,10 +3,6 @@
     "@protected": true,
     "VerifiableCredential": "https://www.w3.org/2018/credentials#VerifiableCredential"
   },
-  "https://www.w3.org/ns/credentials/examples/v2": {
-    "UniversityDegreeCredential": "https://example.org/examples#UniversityDegreeCredential",
-    "RelationshipCredential": "https://example.org/examples#RelationshipCredential"
-  },
   "https://example.org/cool.json": {},
   "https://example.org/specific-application/pre": {},
   "https://example.org/specific-application/post": {},

--- a/tests/input/credential-context-combo1-ok.json
+++ b/tests/input/credential-context-combo1-ok.json
@@ -1,7 +1,11 @@
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+   {
+     "@context": {
+       "@vocab": "https://www.w3.org/ns/credentials/examples#"
+     }
+   }
   ],
   "type": [
     "VerifiableCredential"

--- a/tests/input/credential-missing-base-context-fail.json
+++ b/tests/input/credential-missing-base-context-fail.json
@@ -1,7 +1,9 @@
 {
-  "@context": [
-    "https://www.w3.org/ns/credentials/examples/v2"
-  ],
+  "@context": [{
+    "@context": {
+      "@vocab": "https://www.w3.org/ns/credentials/examples#"
+    }
+  }],
   "type": [
     "VerifiableCredential"
   ],

--- a/tests/input/credential-missing-required-type-fail.json
+++ b/tests/input/credential-missing-required-type-fail.json
@@ -1,7 +1,11 @@
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+   {
+     "@context": {
+       "@vocab": "https://www.w3.org/ns/credentials/examples#"
+     }
+   }
   ],
   "type": [
     "RelationshipCredential"

--- a/tests/input/credential-optional-type-ok.json
+++ b/tests/input/credential-optional-type-ok.json
@@ -1,7 +1,11 @@
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
-    "https://www.w3.org/ns/credentials/examples/v2"
+   {
+     "@context": {
+       "@vocab": "https://www.w3.org/ns/credentials/examples#"
+     }
+   }
   ],
   "type": [
     "VerifiableCredential",

--- a/tests/input/presentation-missing-base-context-fail.json
+++ b/tests/input/presentation-missing-base-context-fail.json
@@ -1,7 +1,9 @@
 {
-  "@context": [
-    "https://www.w3.org/ns/credentials/examples/v2"
-  ],
+  "@context": [{
+     "@context": {
+       "@vocab": "https://www.w3.org/ns/credentials/examples#"
+     }
+  }],
   "type": [
     "VerifiablePresentation"
   ],


### PR DESCRIPTION
Replaces the examples context with an inline version of that context.
This is to reduce the number of contexts implementers will need to resolve on their issuers and verifiers.

p.s. there are more test specific contexts in this suite, but the examples one gets used a lot and is pretty simple.