### PR TITLE
Check id tests

### DIFF
--- a/contexts.json
+++ b/contexts.json
@@ -7,7 +7,6 @@
     "UniversityDegreeCredential": "https://example.org/examples#UniversityDegreeCredential",
     "RelationshipCredential": "https://example.org/examples#RelationshipCredential"
   },
-  "https://example.org/cool.json": {},
   "https://example.org/specific-application/pre": {},
   "https://example.org/specific-application/post": {},
   "https://example.org/ns/test-credential-pre": {},

--- a/tests/input/credential-id-other-ok.json
+++ b/tests/input/credential-id-other-ok.json
@@ -1,7 +1,6 @@
 {
   "@context": [
-    "https://www.w3.org/ns/credentials/v2",
-    "https://example.org/cool.json"
+    "https://www.w3.org/ns/credentials/v2"
   ],
   "type": [
     "VerifiableCredential"
@@ -9,7 +8,6 @@
   "validFrom": "2023-02-22T21:35:22Z",
   "issuer": "did:example:other-issuer",
   "credentialSubject": {
-    "id": "did:example:subject",
-    "isCool": true
+    "id": "did:example:subject"
   }
 }

--- a/tests/input/credential-not-url-id-fail.json
+++ b/tests/input/credential-not-url-id-fail.json
@@ -9,6 +9,6 @@
   "validFrom": "2023-02-22T21:52:06Z",
   "issuer": "did:example:issuer",
   "credentialSubject": {
-    "id": "did:key:zFoo"
+    "name": "id not a url test"
   }
 }

--- a/tests/input/credential-not-url-id-fail.json
+++ b/tests/input/credential-not-url-id-fail.json
@@ -9,6 +9,6 @@
   "validFrom": "2023-02-22T21:52:06Z",
   "issuer": "did:example:issuer",
   "credentialSubject": {
-    "description": "Something"
+    "id": "did:key:zFoo"
   }
 }

--- a/tests/input/credential-single-id-ok.json
+++ b/tests/input/credential-single-id-ok.json
@@ -9,6 +9,6 @@
   "validFrom": "2023-02-22T21:31:29Z",
   "issuer": "did:example:issuer",
   "credentialSubject": {
-    "id": "did:key:zFoo"
+    "description": "A single id test for Vc 2.0"
   }
 }

--- a/tests/input/credential-single-id-ok.json
+++ b/tests/input/credential-single-id-ok.json
@@ -9,6 +9,6 @@
   "validFrom": "2023-02-22T21:31:29Z",
   "issuer": "did:example:issuer",
   "credentialSubject": {
-    "description": "A single id test for Vc 2.0"
+    "description": "A single id test for VC 2.0"
   }
 }

--- a/tests/input/credential-single-id-ok.json
+++ b/tests/input/credential-single-id-ok.json
@@ -9,6 +9,6 @@
   "validFrom": "2023-02-22T21:31:29Z",
   "issuer": "did:example:issuer",
   "credentialSubject": {
-    "description": "Some text"
+    "id": "did:key:zFoo"
   }
 }

--- a/tests/input/credential-subject-multiple-ok.json
+++ b/tests/input/credential-subject-multiple-ok.json
@@ -12,7 +12,7 @@
       "id": "did:example:subject"
     },
     {
-      "description": "other subject"
+      "did": "did:example:other:subject"
     }
   ]
 }

--- a/tests/input/credential-subject-multiple-ok.json
+++ b/tests/input/credential-subject-multiple-ok.json
@@ -12,7 +12,7 @@
       "id": "did:example:subject"
     },
     {
-      "did": "did:example:other:subject"
+      "id": "did:example:other:subject"
     }
   ]
 }


### PR DESCRIPTION
Checks the following tests:



if present: "The id property MUST express an identifier that others are expected to use when expressing statements about a specific thing identified by that identifier." | ✓ | ✓ | ✓
if present: "The id property MUST NOT have more than one value." | ✓ | ✓ | ✓
if present: "The value of the id property MUST be a URL which MAY be dereferenced." | ❌ | ✓ | ✓
The value of the id property MUST be a single URL.

Some of these tests were failing because the term `description` was used in them and description is not found in the VC 2.0 context.
It also removes the custom context: `  "https://example.org/cool.json": {},`

