### PR TITLE
Use ?. check on result.errors to prevent test from throwing

### DIFF
--- a/tests/10-vcdm2.js
+++ b/tests/10-vcdm2.js
@@ -91,7 +91,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
     async function verify(vc) {
       const verifyBody = createVerifyRequestBody({vc});
       const result = await post(verifier, verifyBody);
-      if(result.errors.length) {
+      if(result?.errors?.length) {
         throw result.errors[0];
       }
       return result;
@@ -105,7 +105,7 @@ describe('Verifiable Credentials Data Model v2.0', function() {
         }
       };
       const result = await post(vpVerifier, body);
-      if(result.errors.length) {
+      if(result?.errors?.length) {
         throw result.errors[0];
       }
       return result;


### PR DESCRIPTION
the problem:

```js
result?.errors?.length
```

result is undefined this throws (this is rarely the case), but when `result.errors` is undefined this throws which is often the case. This results in invalid test results where a call on `verify` will fail because `result.errors` is not defined.